### PR TITLE
add missing call to icepack_init_wave

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/CICE_InitMod.F90
+++ b/cicecore/drivers/nuopc/cmeps/CICE_InitMod.F90
@@ -35,6 +35,7 @@ contains
     use ice_grid          , only: init_grid1, alloc_grid
     use ice_domain        , only: init_domain_blocks
     use ice_arrays_column , only: alloc_arrays_column
+    use ice_arrays_column , only: wavefreq, dwavefreq, wave_spectrum
     use ice_state         , only: alloc_state
     use ice_dyn_shared    , only: alloc_dyn_shared
     use ice_flux_bgc      , only: alloc_flux_bgc
@@ -78,7 +79,7 @@ contains
     use ice_calendar         , only: dt, dt_dyn, istep, istep1, write_ic, init_calendar, calendar
     use ice_communicate      , only: my_task, master_task
     use ice_diagnostics      , only: init_diags
-    use ice_domain_size      , only: ncat, nfsd
+    use ice_domain_size      , only: ncat, nfsd, nfreq
     use ice_dyn_eap          , only: init_eap, alloc_dyn_eap
     use ice_dyn_shared       , only: kdyn, init_dyn
     use ice_dyn_vp           , only: init_vp
@@ -94,10 +95,12 @@ contains
     use ice_restoring        , only: ice_HaloRestore_init
     use ice_timers           , only: timer_total, init_ice_timers, ice_timer_start
     use ice_transport_driver , only: init_transport
+    use ice_arrays_column    , only: wavefreq, dwavefreq
 
     logical(kind=log_kind) :: tr_aero, tr_zaero, skl_bgc, z_tracers
     logical(kind=log_kind) :: tr_iso, tr_fsd, wave_spec, tr_snow
     character(len=char_len) :: snw_aging_table
+    real(kind=dbl_kind), dimension(25) :: wave_spectrum_profile    ! hardwire for now
     character(len=*), parameter :: subname = '(cice_init2)'
     !----------------------------------------------------
 
@@ -176,6 +179,11 @@ contains
           call init_snowtable()
        endif
     endif
+
+    if (wave_spec) then
+       call icepack_init_wave(nfreq=nfreq, &
+            wave_spectrum_profile=wave_spectrum_profile, wavefreq=wavefreq, dwavefreq=dwavefreq)
+    end if
 
     ! Initialize shortwave components using swdn from previous timestep
     ! if restarting. These components will be scaled to current forcing


### PR DESCRIPTION
## PR checklist
- [x] Short (1 sentence) summary of your PR: 
add missing call to icepack_init_wave
- [x] Developer(s): mvertens
- [x] Suggest PR reviewers from list in the column to the right.
- [x] Please copy the PR test results link or provide a summary of testing completed below.
SMS.TL319_t061_wt061.GMOM_JRA_WD.cheyenne_intel with this change shows that the iceImp_Si_floediam from CICE6 to the mediator changes after the first coupling interval
- How much do the PR code changes differ from the unmodified code? 
    - [x] bit for bit (except for wav/ice coupling - this needs to be tested)
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [ ] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [x] Yes
        - [ ] No 
- [ ] Please provide any additional information or relevant details below:
