### PR TITLE
reorder for async io initialization

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -17,12 +17,13 @@ module ice_comp_nuopc
   use NUOPC_Model        , only : NUOPC_ModelGet, SetVM
   use ice_constants      , only : ice_init_constants, c0
   use ice_shr_methods    , only : chkerr, state_setscalar, state_getscalar, state_diagnose, alarmInit
-  use ice_shr_methods    , only : set_component_logging, get_component_instance, state_flddebug
+  use ice_shr_methods    , only : get_component_instance, state_flddebug
+
   use ice_import_export  , only : ice_import, ice_export, ice_advertise_fields, ice_realize_fields
   use ice_domain_size    , only : nx_global, ny_global
   use ice_grid           , only : grid_type, init_grid2
   use ice_communicate    , only : init_communicate, my_task, master_task, mpi_comm_ice
-  use ice_calendar       , only : force_restart_now, write_ic
+  use ice_calendar       , only : force_restart_now, write_ic, init_calendar
   use ice_calendar       , only : idate, mday, mmonth, myear, year_init
   use ice_calendar       , only : msec, dt, calendar, calendar_type, nextsw_cday, istep
   use ice_calendar       , only : ice_calendar_noleap, ice_calendar_gregorian
@@ -41,6 +42,9 @@ module ice_comp_nuopc
   use shr_const_mod
   use shr_orb_mod        , only : shr_orb_decl, shr_orb_params, SHR_ORB_UNDEF_REAL, SHR_ORB_UNDEF_INT
   use ice_scam           , only : scmlat, scmlon, scol_mask, scol_frac, scol_ni, scol_nj
+  use nuopc_shr_methods  , only : set_component_logging
+#else
+  use ice_shr_methods    , only : set_component_logging
 #endif
   use ice_timers
   use CICE_InitMod       , only : cice_init1, cice_init2
@@ -87,6 +91,15 @@ module ice_comp_nuopc
 
   integer                      :: dbug = 0
   logical                      :: profile_memory = .false.
+  logical                      :: mastertask
+  integer                      :: start_ymd          ! Start date (YYYYMMDD)
+  integer                      :: start_tod          ! start time of day (s)
+  integer                      :: curr_ymd           ! Current date (YYYYMMDD)
+  integer                      :: curr_tod           ! Current time of day (s)
+  integer                      :: stop_ymd           ! stop date (YYYYMMDD)
+  integer                      :: stop_tod           ! stop time of day (sec)
+  integer                      :: ref_ymd            ! Reference date (YYYYMMDD)
+  integer                      :: ref_tod            ! reference time of day (s)
   integer     , parameter      :: debug_import = 0 ! internal debug level
   integer     , parameter      :: debug_export = 0 ! internal debug level
   character(*), parameter      :: modName =  "(ice_comp_nuopc)"
@@ -201,12 +214,8 @@ contains
     real(kind=dbl_kind)          :: atmiter_conv_driver
     integer (kind=int_kind)      :: natmiter
     integer (kind=int_kind)      :: natmiter_driver
-    character(len=char_len)      :: tfrz_option_driver       ! tfrz_option from driver attributes
-    character(len=char_len)      :: tfrz_option    ! tfrz_option from cice namelist
-    integer(int_kind)            :: ktherm
     integer                      :: localPet
     integer                      :: npes
-    logical                      :: mastertask
     type(ESMF_VM)                :: vm
     integer                      :: lmpicom            ! local communicator
     type(ESMF_Time)              :: currTime           ! Current time
@@ -215,14 +224,6 @@ contains
     type(ESMF_Time)              :: refTime            ! Ref time
     type(ESMF_TimeInterval)      :: timeStep           ! Model timestep
     type(ESMF_CalKind_Flag)      :: esmf_caltype       ! esmf calendar type
-    integer                      :: start_ymd          ! Start date (YYYYMMDD)
-    integer                      :: start_tod          ! start time of day (s)
-    integer                      :: curr_ymd           ! Current date (YYYYMMDD)
-    integer                      :: curr_tod           ! Current time of day (s)
-    integer                      :: stop_ymd           ! stop date (YYYYMMDD)
-    integer                      :: stop_tod           ! stop time of day (sec)
-    integer                      :: ref_ymd            ! Reference date (YYYYMMDD)
-    integer                      :: ref_tod            ! reference time of day (s)
     integer                      :: yy,mm,dd           ! Temporaries for time query
     integer                      :: dtime              ! time step
     integer                      :: shrlogunit         ! original log unit
@@ -232,12 +233,15 @@ contains
     integer                      :: iblk, jblk         ! indices
     integer                      :: ig, jg             ! indices
     integer                      :: ilo, ihi, jlo, jhi ! beginning and end of physical domain
+
     character(len=char_len_long) :: diag_filename = 'unset'
     character(len=char_len_long) :: logmsg
     character(len=char_len_long) :: single_column_lnd_domainfile
     real(dbl_kind)               :: scol_lon
     real(dbl_kind)               :: scol_lat
     real(dbl_kind)               :: scol_spval
+    character(len=char_len)      :: tfrz_option    ! tfrz_option from cice namelist
+    character(len=char_len)      :: tfrz_option_driver    ! tfrz_option from cice namelist
     character(len=*), parameter :: subname=trim(modName)//':(InitializeAdvertise) '
     !--------------------------------
 
@@ -560,13 +564,18 @@ contains
           RETURN
        end if
     end if
-
     ! Read the cice namelist as part of the call to cice_init1
     ! Note that if single_column is true and scol_valid is not - will never get here
-
     call t_startf ('cice_init1')
     call cice_init1
     call t_stopf ('cice_init1')
+
+    !-----------------------------------------------------------------
+    ! Advertise fields
+    !-----------------------------------------------------------------
+    call ice_advertise_fields(gcomp, importState, exportState, flds_scalar_name, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
 
     ! Form of ocean freezing temperature
     ! 'minus1p8' = -1.8 C
@@ -676,6 +685,52 @@ contains
        end if
     end if
 
+    call init_calendar()
+
+    call calendar()     ! update calendar info
+    ! NOTE: the advertise phase needs to be called after the ice
+    ! initialization since the number of ice categories is needed for
+    ! ice_fraction_n and mean_sw_pen_to_ocn_ifrac_n
+!    call ice_advertise_fields(gcomp, importState, exportState, flds_scalar_name, rc)
+!    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call t_stopf ('cice_init_total')
+
+  end subroutine InitializeAdvertise
+
+  !===============================================================================
+
+  subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
+
+    ! Arguments
+    type(ESMF_GridComp)  :: gcomp
+    type(ESMF_State)     :: importState
+    type(ESMF_State)     :: exportState
+    type(ESMF_Clock)     :: clock
+    integer, intent(out) :: rc
+
+    ! Local variables
+    integer                                :: n
+    integer                                :: fieldcount
+    type(ESMF_Field)                       :: lfield
+    character(len=char_len_long)           :: cvalue
+    real(dbl_kind)                         :: scol_lon
+    real(dbl_kind)                         :: scol_lat
+    real(dbl_kind)                         :: scol_spval
+    real(dbl_kind), pointer                :: fldptr1d(:)
+    real(dbl_kind), pointer                :: fldptr2d(:,:)
+    integer                                :: rank
+    character(len=char_len)      :: tfrz_option    ! tfrz_option from cice namelist
+    integer(int_kind)            :: ktherm
+
+    character(len=char_len_long)           :: single_column_lnd_domainfile
+    character(len=char_len_long) , pointer :: lfieldnamelist(:) => null()
+    character(len=*), parameter            :: subname=trim(modName)//':(InitializeRealize) '
+    !--------------------------------
+
+    rc = ESMF_SUCCESS
+    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO)
+
     !----------------------------------------------------------------------------
     ! Second cice initialization phase -after initializing grid info
     !----------------------------------------------------------------------------
@@ -686,29 +741,6 @@ contains
     call t_startf ('cice_init2')
     call cice_init2()
     call t_stopf ('cice_init2')
-
-    !----------------------------------------------------------------------------
-    ! reset shr logging to my log file
-    !----------------------------------------------------------------------------
-
-    call icepack_query_parameters(ktherm_out=ktherm)
-    call icepack_query_parameters(tfrz_option_out=tfrz_option)
-    call icepack_warnings_flush(nu_diag)
-    if (icepack_warnings_aborted()) call abort_ice(error_message=subname, &
-        file=__FILE__, line=__LINE__)
-
-    ! Now write output to nu_diag - this must happen AFTER call to cice_init
-    if (mastertask) then
-       write(nu_diag,'(a,d21.14)') trim(subname)//' cice init nextsw_cday = ',nextsw_cday
-       write(nu_diag,'(a)') trim(subname)//' tfrz_option = '//trim(tfrz_option)
-       if (ktherm == 2 .and. trim(tfrz_option) /= 'mushy') then
-          write(nu_diag,*) trim(subname),' Warning: Using ktherm = 2 and tfrz_option = ', trim(tfrz_option)
-       endif
-       write(nu_diag,'(a    )') trim(subname)//' inst_name   = '//trim(inst_name)
-       write(nu_diag,'(a,i8 )') trim(subname)//' inst_index  = ',inst_index
-       write(nu_diag,'(a    )') trim(subname)//' inst_suffix = ',trim(inst_suffix)
-    endif
-
     !---------------------------------------------------------------------------
     ! use EClock to reset calendar information on initial start
     !---------------------------------------------------------------------------
@@ -757,8 +789,29 @@ contains
        endif
 
     end if
+    !----------------------------------------------------------------------------
+    ! reset shr logging to my log file
+    !----------------------------------------------------------------------------
 
-    call calendar()     ! update calendar info
+    call icepack_query_parameters(ktherm_out=ktherm)
+    call icepack_query_parameters(tfrz_option_out=tfrz_option)
+    call icepack_warnings_flush(nu_diag)
+    if (icepack_warnings_aborted()) call abort_ice(error_message=subname, &
+        file=__FILE__, line=__LINE__)
+
+    ! Now write output to nu_diag - this must happen AFTER call to cice_init
+    if (mastertask) then
+       write(nu_diag,'(a,d21.14)') trim(subname)//' cice init nextsw_cday = ',nextsw_cday
+       write(nu_diag,'(a)') trim(subname)//' tfrz_option = '//trim(tfrz_option)
+       if (ktherm == 2 .and. trim(tfrz_option) /= 'mushy') then
+          write(nu_diag,*) trim(subname),' Warning: Using ktherm = 2 and tfrz_option = ', trim(tfrz_option)
+       endif
+       write(nu_diag,'(a    )') trim(subname)//' inst_name   = '//trim(inst_name)
+       write(nu_diag,'(a,i8 )') trim(subname)//' inst_index  = ',inst_index
+       write(nu_diag,'(a    )') trim(subname)//' inst_suffix = ',trim(inst_suffix)
+    endif
+
+
     if (write_ic) then
        call accum_hist(dt)  ! write initial conditions
     end if
@@ -769,50 +822,6 @@ contains
 
     call ice_prescribed_init(clock, ice_mesh, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    !-----------------------------------------------------------------
-    ! Advertise fields
-    !-----------------------------------------------------------------
-
-    ! NOTE: the advertise phase needs to be called after the ice
-    ! initialization since the number of ice categories is needed for
-    ! ice_fraction_n and mean_sw_pen_to_ocn_ifrac_n
-    call ice_advertise_fields(gcomp, importState, exportState, flds_scalar_name, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    call t_stopf ('cice_init_total')
-
-  end subroutine InitializeAdvertise
-
-  !===============================================================================
-
-  subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
-
-    ! Arguments
-    type(ESMF_GridComp)  :: gcomp
-    type(ESMF_State)     :: importState
-    type(ESMF_State)     :: exportState
-    type(ESMF_Clock)     :: clock
-    integer, intent(out) :: rc
-
-    ! Local variables
-    integer                                :: n
-    integer                                :: fieldcount
-    type(ESMF_Field)                       :: lfield
-    character(len=char_len_long)           :: cvalue
-    real(dbl_kind)                         :: scol_lon
-    real(dbl_kind)                         :: scol_lat
-    real(dbl_kind)                         :: scol_spval
-    real(dbl_kind), pointer                :: fldptr1d(:)
-    real(dbl_kind), pointer                :: fldptr2d(:,:)
-    integer                                :: rank
-    character(len=char_len_long)           :: single_column_lnd_domainfile
-    character(len=char_len_long) , pointer :: lfieldnamelist(:) => null()
-    character(len=*), parameter            :: subname=trim(modName)//':(InitializeRealize) '
-    !--------------------------------
-
-    rc = ESMF_SUCCESS
-    if (dbug > 5) call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO)
 
 #ifdef CESMCOUPLED
     ! if single column is not valid - set all export state fields to zero and return
@@ -849,7 +858,7 @@ contains
        ! *** RETURN HERE ***
        ! *******************
        RETURN
-    else
+    else if(single_column) then
        write(nu_diag,'(a,3(f10.5,2x))')' (ice_comp_nuopc) single column mode lon/lat/frac is ',&
             scmlon,scmlat,scol_frac
     end if
@@ -891,6 +900,7 @@ contains
        call state_diagnose(exportState,subname//':ES',rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     endif
+    call calendar()     ! update calendar info
 
     if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO)
 


### PR DESCRIPTION
This reorders CICE initialization so that IO does not happen until the realize phase.

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    This reorders CICE initialization so that IO does not happen until the realize phase.
- [X] Developer(s): 
    Jim Edwards
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Tested in CESM prealphas on cheyenne comparing to cesm2_3_alpha09c

- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [ ] Please provide any additional information or relevant details below:
