### PR TITLE
Improve lon diff

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90
@@ -639,9 +639,8 @@ contains
 
              tmplon = lon(n)
              if(tmplon < c0)tmplon = tmplon + c360
-
              ! error check differences between internally generated lons and those read in
-             diff_lon = abs(mod(lonMesh(n) - tmplon,360.0))
+             diff_lon = abs(mod(2*c360+lonMesh(n),c360) - mod(2*c360+tmplon,c360))
              if (diff_lon > eps_imesh ) then
                 write(6,100)n,lonMesh(n),tmplon, diff_lon
                 !call abort_ice(error_message=subname, file=__FILE__, line=__LINE__)

--- a/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90
@@ -583,7 +583,7 @@ contains
     real(dbl_kind)               :: diff_lon
     real(dbl_kind)               :: diff_lat
     real(dbl_kind)               :: rad_to_deg
-    real(dbl_kind)               :: tmplon, eps_imesh
+    real(dbl_kind)               :: eps_imesh
     logical                      :: isPresent, isSet
     logical                      :: mask_error
     integer                      :: mask_internal
@@ -637,12 +637,10 @@ contains
              lon(n) = tlon(i,j,iblk)*rad_to_deg
              lat(n) = tlat(i,j,iblk)*rad_to_deg
 
-             tmplon = lon(n)
-             if(tmplon < c0)tmplon = tmplon + c360
              ! error check differences between internally generated lons and those read in
-             diff_lon = abs(mod(2*c360+lonMesh(n),c360) - mod(2*c360+tmplon,c360))
+             diff_lon = abs(mod(2*c360+lonMesh(n),c360) - mod(2*c360+lon(n),c360))
              if (diff_lon > eps_imesh ) then
-                write(6,100)n,lonMesh(n),tmplon, diff_lon
+                write(6,100)n,lonMesh(n),lon(n), diff_lon
                 !call abort_ice(error_message=subname, file=__FILE__, line=__LINE__)
              end if
              diff_lat = abs(latMesh(n) - lat(n))


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Avoid erroneous CESM error messages by insuring lon_diff works correctly.
- [X] Developer(s): 
    Jim Edwards
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Tested using SMS_Ld2.ne30pg3_t232.BLT1850_v0c.cheyenne_intel.allactive-defaultio
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please provide any additional information or relevant details below:
We need to assure that the result of both mod calculations are 0<= x < 360, we do that by adding 720 to both values before computing the mod base 360.   For this test case the number of (incorrect) error messages in the CESM log went from 87726 to 0.  