### PR TITLE
Update the opticep unit test to be consistent with the latest changes.

### DIFF
--- a/cicecore/cicedyn/general/ice_step_mod.F90
+++ b/cicecore/cicedyn/general/ice_step_mod.F90
@@ -766,7 +766,7 @@
       real (kind=dbl_kind), dimension(:,:,:), intent(inout), optional :: &
          daidt, & ! change in ice area per time step
          dvidt, & ! change in ice volume per time step
-         dvsdt, & ! change in snow  volume per time step
+         dvsdt, & ! change in snow volume per time step
          dagedt   ! change in ice age per time step
 
       real (kind=dbl_kind), intent(in), optional :: &

--- a/cicecore/drivers/unittest/opticep/CICE_InitMod.F90
+++ b/cicecore/drivers/unittest/opticep/CICE_InitMod.F90
@@ -66,7 +66,7 @@
           floe_binwidth, c_fsd_range
       use ice_state, only: alloc_state
       use ice_flux_bgc, only: alloc_flux_bgc
-      use ice_calendar, only: dt, dt_dyn, write_ic, &
+      use ice_calendar, only: dt, write_ic, &
           init_calendar, advance_timestep, calc_timesteps
       use ice_communicate, only: init_communicate, my_task, master_task
       use ice_diagnostics, only: init_diags
@@ -244,6 +244,7 @@
       call init_flux_ocn        ! initialize ocean fluxes sent to coupler
 
       call dealloc_grid         ! deallocate temporary grid arrays
+
       if (my_task == master_task) then
          call ice_memusage_print(nu_diag,subname//':end')
       endif

--- a/cicecore/drivers/unittest/opticep/CICE_RunMod.F90
+++ b/cicecore/drivers/unittest/opticep/CICE_RunMod.F90
@@ -307,7 +307,7 @@
 
             ! clean up, update tendency diagnostics
             offset = c0
-            call update_state (dt=dt_dyn, daidtd=daidtd, dvidt=dvidtd, dvsdt=dvsdtd, &
+            call update_state (dt=dt_dyn, daidt=daidtd, dvidt=dvidtd, dvsdt=dvsdtd, &
                                dagedt=dagedtd, offset=offset)
 
          enddo


### PR DESCRIPTION

Update the opticep unit test source code to be consistent with the latest changes.

I tested the current PR without these changes and everything works fine.  So this is not needed, but this will need to be done at some point just to keep the unit test source code up to date.