### PR TITLE
added the REST_OPTION=end

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -1290,6 +1290,30 @@ contains
        call ESMF_LogWrite(subname//'setting alarms for ' // trim(name), ESMF_LOGMSG_INFO)
 
        !----------------
+       ! Stop alarm - must be set first, since restart alarm may be based on this value
+       !----------------
+       call NUOPC_CompAttributeGet(gcomp, name="stop_option", value=stop_option, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       call NUOPC_CompAttributeGet(gcomp, name="stop_n", value=cvalue, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       read(cvalue,*) stop_n
+
+       call NUOPC_CompAttributeGet(gcomp, name="stop_ymd", value=cvalue, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       read(cvalue,*) stop_ymd
+
+       call alarmInit(mclock, stop_alarm, stop_option, &
+            opt_n   = stop_n,           &
+            opt_ymd = stop_ymd,         &
+            RefTime = mcurrTime,           &
+            alarmname = 'alarm_stop', rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       call ESMF_AlarmSet(stop_alarm, clock=mclock, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       !----------------
        ! Restart alarm
        !----------------
        call NUOPC_CompAttributeGet(gcomp, name="restart_option", value=restart_option, rc=rc)
@@ -1311,30 +1335,6 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
        call ESMF_AlarmSet(restart_alarm, clock=mclock, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-       !----------------
-       ! Stop alarm
-       !----------------
-       call NUOPC_CompAttributeGet(gcomp, name="stop_option", value=stop_option, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-       call NUOPC_CompAttributeGet(gcomp, name="stop_n", value=cvalue, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       read(cvalue,*) stop_n
-
-       call NUOPC_CompAttributeGet(gcomp, name="stop_ymd", value=cvalue, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       read(cvalue,*) stop_ymd
-
-       call alarmInit(mclock, stop_alarm, stop_option, &
-            opt_n   = stop_n,           &
-            opt_ymd = stop_ymd,         &
-            RefTime = mcurrTime,           &
-            alarmname = 'alarm_stop', rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-       call ESMF_AlarmSet(stop_alarm, clock=mclock, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     end if

--- a/cicecore/drivers/nuopc/cmeps/ice_shr_methods.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_shr_methods.F90
@@ -15,7 +15,7 @@ module ice_shr_methods
   use ESMF         , only : ESMF_ClockPrint, ESMF_ClockAdvance
   use ESMF         , only : ESMF_Alarm, ESMF_AlarmCreate, ESMF_AlarmGet, ESMF_AlarmSet
   use ESMF         , only : ESMF_Calendar, ESMF_CALKIND_NOLEAP, ESMF_CALKIND_GREGORIAN
-  use ESMF         , only : ESMF_Time, ESMF_TimeGet, ESMF_TimeSet
+  use ESMF         , only : ESMF_Time, ESMF_TimeGet, ESMF_TimeSet, ESMF_ClockGetAlarm
   use ESMF         , only : ESMF_TimeInterval, ESMF_TimeIntervalSet, ESMF_TimeIntervalGet
   use ESMF         , only : ESMF_VM, ESMF_VMGet, ESMF_VMBroadcast, ESMF_VMGetCurrent
   use NUOPC        , only : NUOPC_CompAttributeGet
@@ -925,7 +925,9 @@ contains
     case (optEnd)
        call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       call ESMF_TimeSet( NextAlarm, yy=9999, mm=12, dd=1, s=0, calendar=cal, rc=rc )
+       call ESMF_ClockGetAlarm(clock, "alarm_stop", alarm, rc=rc) 
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_AlarmGet(alarm, ringTime=NextAlarm, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        update_nextalarm  = .false.
 

--- a/cicecore/drivers/nuopc/cmeps/ice_shr_methods.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_shr_methods.F90
@@ -65,6 +65,7 @@ module ice_shr_methods
        optMonthly        = "monthly"   , &
        optYearly         = "yearly"    , &
        optDate           = "date"      , &
+       optEnd            = "end"       , &
        optIfdays0        = "ifdays0"
 
   ! Module data
@@ -756,6 +757,7 @@ contains
        update_nextalarm  = .true.
 
     case (optNStep)
+       ! This only works if ice_cpl_dt == minimum_timestep
        if (.not.present(opt_n)) call abort_ice(subname//trim(option)//' requires opt_n')
        if (opt_n <= 0)  call abort_ice(subname//trim(option)//' invalid opt_n')
        call ESMF_ClockGet(clock, TimeStep=AlarmInterval, rc=rc)
@@ -919,6 +921,13 @@ contains
        call ESMF_TimeSet( NextAlarm, yy=cyy, mm=1, dd=1, s=0, calendar=cal, rc=rc )
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        update_nextalarm  = .true.
+
+    case (optEnd)
+       call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_TimeSet( NextAlarm, yy=9999, mm=12, dd=1, s=0, calendar=cal, rc=rc )
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       update_nextalarm  = .false.
 
     case default
        call abort_ice(subname//'unknown option '//trim(option))


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>

Fixes issue #29 

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Add support for REST_OPTION=end
- [X] Developer(s): 
    Jim Edwards
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Tested with cesm2_3_alpha17c using case and REST_OPTION=end 
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [S] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.
In the process of fixing an issue with ALARM_OPTION=nsteps I noticed that the ALARM_OPTION=end value was documented but didn't work.  ./