### PR TITLE
reduce orbital parameters output to log

### DIFF
--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -404,6 +404,7 @@ contains
     ! Determine attributes - also needed in realize phase to get grid information
     !----------------------------------------------------------------------------
 
+
     ! Get orbital values
     ! Note that these values are obtained in a call to init_orbit in ice_shortwave.F90
     ! if CESMCOUPLED is not defined
@@ -1520,11 +1521,14 @@ contains
     else
        orb_year = orb_iyear
     end if
+
     if (orb_year .ne. prev_orb_year) then
        lprint = mastertask
-       prev_orb_year = orb_year
+       ! this prevents the orbital print happening before the log file is opened.
+       if (.not. first_time) prev_orb_year = orb_year
     endif
     eccen = orb_eccen
+
     call shr_orb_params(orb_year, eccen, orb_obliq, orb_mvelp, obliqr, lambm0, mvelpp, lprint)
 
     if ( eccen  == SHR_ORB_UNDEF_REAL .or. obliqr == SHR_ORB_UNDEF_REAL .or. &

--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
@@ -1426,8 +1426,9 @@ contains
     type(ESMF_Time)              :: CurrTime ! current time
     integer                      :: year     ! model year at current time
     integer                      :: orb_year ! orbital year for current orbital computation
+    integer, save                :: prev_orb_year=0 ! orbital year for previous orbital computation
     logical                      :: lprint
-    logical                      :: first_time = .true.
+    logical, save                :: first_time = .true.
     character(len=*) , parameter :: subname = "(cice_orbital_init)"
     !-------------------------------------------------------------------------------
 
@@ -1509,23 +1510,20 @@ contains
           return  ! bail out
        endif
     end if
-
+    lprint = .false.
     if (trim(orb_mode) == trim(orb_variable_year)) then
        call ESMF_ClockGet(clock, CurrTime=CurrTime, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        call ESMF_TimeGet(CurrTime, yy=year, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        orb_year = orb_iyear + (year - orb_iyear_align)
-       lprint = mastertask
     else
        orb_year = orb_iyear
-       if (first_time) then
-          lprint = mastertask
-       else
-          lprint = .false.
-       end if
     end if
-
+    if (orb_year .ne. prev_orb_year) then
+       lprint = mastertask
+       prev_orb_year = orb_year
+    endif
     eccen = orb_eccen
     call shr_orb_params(orb_year, eccen, orb_obliq, orb_mvelp, obliqr, lambm0, mvelpp, lprint)
 


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Reduces the printing of Orbital parameters to the ice.log file in cesm
- [X] Developer(s): 
    Jim Edwards
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Test 
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [x] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.
The orbital parameters were being printed every timestep and created an unreadable ice.log file.  This PR reduces the print of orbital parameters to once each orbital year.