### PR TITLE
Wrt restart at end

### DIFF
--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
@@ -54,7 +54,7 @@
       ! local variables
 
       character(len=char_len_long) :: &
-         filename, filename0, lpointer_file
+         filename, filename0
       
       integer (kind=int_kind) :: status
 
@@ -68,19 +68,11 @@
          filename = trim(ice_ic)
       else
          if (my_task == master_task) then
-#ifdef CESMCOUPLED
-            write(lpointer_file,'(a,i4.4,a,i2.2,a,i2.2,a,i5.5)') &
-                 trim(pointer_file)//trim(inst_suffix)//'.',myear,'-',mmonth,'-',mday,'-',msec
-            inquire(file=lpointer_file, exist=file_exist)
-            if (.not. file_exist) lpointer_file = trim(pointer_file)//trim(inst_suffix)
-#else
-            lpointer_file = pointer_file
-#endif
-            open(nu_rst_pointer,file=lpointer_file)
+            open(nu_rst_pointer,file=pointer_file)
             read(nu_rst_pointer,'(a)') filename0
             filename = trim(filename0)
             close(nu_rst_pointer)
-            write(nu_diag,*) 'Read ',lpointer_file(1:lenstr(pointer_file))
+            write(nu_diag,*) 'Read ',pointer_file(1:lenstr(pointer_file))
          endif
          call broadcast_scalar(filename, master_task)
       endif

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
@@ -55,13 +55,10 @@
 
       character(len=char_len_long) :: &
          filename, filename0
-      
+
       integer (kind=int_kind) :: status
 
       logical (kind=log_kind), save :: first_call = .true.
-#ifdef CESMCOUPLED
-      logical :: file_exist
-#endif
       character(len=*), parameter :: subname = '(init_restart_read)'
 
       if (present(ice_ic)) then

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
@@ -224,7 +224,7 @@
       if (my_task == master_task) then
 #ifdef CESMCOUPLED
             write(lpointer_file,'(a,i4.4,a,i2.2,a,i2.2,a,i5.5)') &
-                 trim(pointer_file)//trim(inst_suffix)//'.',myear,'-',mmonth,'-',mday,'-',msec
+                 'rpointer.ice'//trim(inst_suffix)//'.',myear,'-',mmonth,'-',mday,'-',msec
 #else
             lpointer_file = pointer_file
 #endif

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
@@ -54,8 +54,8 @@
       ! local variables
 
       character(len=char_len_long) :: &
-         filename, filename0
-
+         filename, filename0, lpointer_file
+      
       integer (kind=int_kind) :: status
 
       logical (kind=log_kind), save :: first_call = .true.
@@ -69,16 +69,18 @@
       else
          if (my_task == master_task) then
 #ifdef CESMCOUPLED
-            write(pointer_file,'(a,i4.4,a,i2.2,a,i2.2,a,i5.5)') &
-                 'rpointer.ice'//trim(inst_suffix)//'.',myear,'-',mmonth,'-',mday,'-',msec
-            inquire(file=pointer_file, exist=file_exist)
-            if (.not. file_exist) pointer_file = 'rpointer.ice'//trim(inst_suffix)
+            write(lpointer_file,'(a,i4.4,a,i2.2,a,i2.2,a,i5.5)') &
+                 trim(pointer_file)//trim(inst_suffix)//'.',myear,'-',mmonth,'-',mday,'-',msec
+            inquire(file=lpointer_file, exist=file_exist)
+            if (.not. file_exist) lpointer_file = trim(pointer_file)//trim(inst_suffix)
+#else
+            lpointer_file = pointer_file
 #endif
-            open(nu_rst_pointer,file=pointer_file)
+            open(nu_rst_pointer,file=lpointer_file)
             read(nu_rst_pointer,'(a)') filename0
             filename = trim(filename0)
             close(nu_rst_pointer)
-            write(nu_diag,*) 'Read ',pointer_file(1:lenstr(pointer_file))
+            write(nu_diag,*) 'Read ',lpointer_file(1:lenstr(pointer_file))
          endif
          call broadcast_scalar(filename, master_task)
       endif
@@ -184,6 +186,7 @@
       integer (kind=int_kind) :: nbtrcr
 
       character(len=char_len_long) :: filename
+      character(len=char_len_long) :: lpointer_file
 
       integer (kind=int_kind) :: &
          dimid_ncat, dimid_nilyr, dimid_nslyr, dimid_naero
@@ -231,10 +234,12 @@
       ! write pointer (path/file)
       if (my_task == master_task) then
 #ifdef CESMCOUPLED
-            write(pointer_file,'(a,i4.4,a,i2.2,a,i2.2,a,i5.5)') &
-                 'rpointer.ice'//trim(inst_suffix)//'.',myear,'-',mmonth,'-',mday,'-',msec
+            write(lpointer_file,'(a,i4.4,a,i2.2,a,i2.2,a,i5.5)') &
+                 trim(pointer_file)//trim(inst_suffix)//'.',myear,'-',mmonth,'-',mday,'-',msec
+#else
+            lpointer_file = pointer_file
 #endif
-         open(nu_rst_pointer,file=pointer_file)
+         open(nu_rst_pointer,file=lpointer_file)
          write(nu_rst_pointer,'(a)') filename
          close(nu_rst_pointer)
       endif

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
@@ -71,7 +71,7 @@
 #ifdef CESMCOUPLED
             write(pointer_file,'(a,i4.4,a,i2.2,a,i2.2,a,i5.5)') &
                  'rpointer.ice'//trim(inst_suffix)//'.',myear,'-',mmonth,'-',mday,'-',msec
-            inquire(file=pointer_file, file_exist=exist)
+            inquire(file=pointer_file, exist=file_exist)
             if (.not. file_exist) pointer_file = 'rpointer.ice'//trim(inst_suffix)
 #endif
             open(nu_rst_pointer,file=pointer_file)

--- a/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
+++ b/cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
@@ -59,7 +59,9 @@
       integer (kind=int_kind) :: status
 
       logical (kind=log_kind), save :: first_call = .true.
-      logical :: exist
+#ifdef CESMCOUPLED
+      logical :: file_exist
+#endif
       character(len=*), parameter :: subname = '(init_restart_read)'
 
       if (present(ice_ic)) then
@@ -69,8 +71,8 @@
 #ifdef CESMCOUPLED
             write(pointer_file,'(a,i4.4,a,i2.2,a,i2.2,a,i5.5)') &
                  'rpointer.ice'//trim(inst_suffix)//'.',myear,'-',mmonth,'-',mday,'-',msec
-            inquire(file=pointer_file, exist=exist)
-            if (.not. exist) pointer_file = 'rpointer.ice'//trim(inst_suffix)
+            inquire(file=pointer_file, file_exist=exist)
+            if (.not. file_exist) pointer_file = 'rpointer.ice'//trim(inst_suffix)
 #endif
             open(nu_rst_pointer,file=pointer_file)
             read(nu_rst_pointer,'(a)') filename0


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Add timestamps to rpointer files for cesm and make sure that write_restart_at_endofrun is working
- [X] Developer(s): 
    Jim Edwards
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Tested with cesm beta test suite

- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.
A timestamp is added to the rpointer filename to improve interactions with restart files in cesm.  CESM has also added a write_restart_at_endofrun option, this PR makes sure that that flag works with the cice component.   