### PR TITLE
Fix baseline comparison issue and merge latest CICE main changes into ESCOMP sealevelponds

### DIFF
--- a/cicecore/cicedyn/general/ice_flux.F90
+++ b/cicecore/cicedyn/general/ice_flux.F90
@@ -1081,7 +1081,7 @@
 
       subroutine init_history_dyn
 
-      use ice_state, only: aice, vice, vsno, trcr, strength, divu, shear
+      use ice_state, only: aice, vice, vsno, trcr, strength, divu, shear, vort
       use ice_grid,  only: grid_ice
 
       logical (kind=log_kind) :: &
@@ -1102,6 +1102,7 @@
       sig2    (:,:,:) = c0
       divu    (:,:,:) = c0
       shear   (:,:,:) = c0
+      vort    (:,:,:) = c0
       taubxU  (:,:,:) = c0
       taubyU  (:,:,:) = c0
       strength (:,:,:) = c0

--- a/cicecore/cicedyn/general/ice_flux.F90
+++ b/cicecore/cicedyn/general/ice_flux.F90
@@ -1209,7 +1209,7 @@
       real (kind=dbl_kind) :: &
           ar, &   ! 1/aice
           stefan_boltzmann, &
-          Tffresh
+          Tffresh, puny
 
       integer (kind=int_kind) :: &
           i, j    ! horizontal indices
@@ -1217,7 +1217,7 @@
       character(len=*), parameter :: subname = '(scale_fluxes)'
 
       call icepack_query_parameters(stefan_boltzmann_out=stefan_boltzmann, &
-         Tffresh_out=Tffresh)
+         Tffresh_out=Tffresh, puny_out=puny)
       call icepack_warnings_flush(nu_diag)
       if (icepack_warnings_aborted()) call abort_ice(error_message=subname, &
          file=__FILE__, line=__LINE__)
@@ -1231,6 +1231,9 @@
             fsens   (i,j) = fsens   (i,j) * ar
             flat    (i,j) = flat    (i,j) * ar
             fswabs  (i,j) = fswabs  (i,j) * ar
+            ! Special case where aice_init was zero and aice > 0.
+            if (flwout(i,j) > -puny) & 
+               flwout  (i,j) = -stefan_boltzmann *(Tf(i,j) + Tffresh)**4
             flwout  (i,j) = flwout  (i,j) * ar
             evap    (i,j) = evap    (i,j) * ar
             Tref    (i,j) = Tref    (i,j) * ar

--- a/cicecore/cicedyn/general/ice_init.F90
+++ b/cicecore/cicedyn/general/ice_init.F90
@@ -1267,7 +1267,7 @@
          endif
          abort_list = trim(abort_list)//":1"
       endif
-      
+
       if (history_format /= 'cdf1'        .and. &
           history_format /= 'cdf2'        .and. &
           history_format /= 'cdf5'        .and. &

--- a/cicecore/cicedyn/general/ice_init.F90
+++ b/cicecore/cicedyn/general/ice_init.F90
@@ -14,7 +14,7 @@
 
       use ice_kinds_mod
       use ice_communicate, only: my_task, master_task, ice_barrier
-      use ice_constants, only: c0, c1, c2, c3, c5, c12, p01, p2, p3, p5, p75, p166, &
+      use ice_constants, only: c0, c1, c2, c3, c5, c10, c12, p01, p2, p3, p5, p75, p166, &
           cm_to_m
       use ice_exit, only: abort_ice
       use ice_fileunits, only: nu_nml, nu_diag, nml_filename, diag_type, &
@@ -239,7 +239,9 @@
         kitd,           ktherm,          conduct,     ksno,             &
         a_rapid_mode,   Rac_rapid_mode,  aspect_rapid_mode,             &
         dSdt_slow_mode, phi_c_slow_mode, phi_i_mushy,                   &
-        floediam,       hfrazilmin,      Tliquidus_max,   hi_min
+        floediam,       hfrazilmin,      Tliquidus_max,   hi_min,       &
+        tscale_pnd_drain
+        
 
       namelist /dynamics_nml/ &
         kdyn,           ndte,           revised_evp,    yield_curve,    &
@@ -267,7 +269,6 @@
 
       namelist /ponds_nml/ &
         hs0,            dpscale,         frzpnd,                        &
-        tscale_pnd_drain, & 
         rfracmin,       rfracmax,        pndaspect,     hs1,            &
         hp1
 
@@ -500,7 +501,7 @@
       rfracmin  = 0.15_dbl_kind   ! minimum retained fraction of meltwater
       rfracmax  = 0.85_dbl_kind   ! maximum retained fraction of meltwater
       pndaspect = 0.8_dbl_kind    ! ratio of pond depth to area fraction
-      tscale_pnd_drain = 0.5
+      tscale_pnd_drain = c10      ! mushy macroscopic drainage timescale (days)
       snwredist = 'none'          ! type of snow redistribution
       snw_aging_table = 'test'    ! snow aging lookup table
       snw_filename    = 'unknown' ! snowtable filename

--- a/cicecore/cicedyn/general/ice_step_mod.F90
+++ b/cicecore/cicedyn/general/ice_step_mod.F90
@@ -217,7 +217,7 @@
 
       subroutine step_therm1 (dt, iblk)
 
-      use ice_arrays_column, only: ffracn, dhsn, pndasp, &
+      use ice_arrays_column, only: ffracn, dhsn, &
           Cdn_ocn, Cdn_ocn_skin, Cdn_ocn_floe, Cdn_ocn_keel, Cdn_atm_ratio, &
           Cdn_atm, Cdn_atm_skin, Cdn_atm_floe, Cdn_atm_rdg, Cdn_atm_pond, &
           hfreebd, hdraft, hridge, distrdg, hkeel, dkeel, lfloe, dfloe, &
@@ -521,7 +521,6 @@
                       H2_16O_ocn   = H2_16O_ocn  (i,j,  iblk), &
                       H2_18O_ocn   = H2_18O_ocn  (i,j,  iblk), &
                       dhsn         = dhsn        (i,j,:,iblk), &
-                      pndasp_in    = pndasp      (i,j,:,iblk),   &
                       ffracn       = ffracn      (i,j,:,iblk), &
                       meltt        = meltt       (i,j,  iblk), &
                       melttn       = melttn      (i,j,:,iblk), &

--- a/cicecore/cicedyn/infrastructure/ice_grid.F90
+++ b/cicecore/cicedyn/infrastructure/ice_grid.F90
@@ -351,12 +351,12 @@
           trim(grid_type) == 'regional'     ) then
 
          if (trim(grid_format) == 'nc') then
-            
+
             fieldname='ulat'
             call ice_open_nc(grid_file,fid_grid)
             call ice_read_global_nc(fid_grid,1,fieldname,work_g1,.true.)
             call ice_close_nc(fid_grid)
-            
+
             ! mask variable name might be kmt or mask, check both
             call ice_open_nc(kmt_file,fid_kmt)
 #ifdef USE_NETCDF
@@ -364,7 +364,7 @@
                status = nf90_inq_varid(fid_kmt, 'kmt', varid)
                if (status == nf90_noerr) then
                   mask_fieldname = 'kmt'
-               else 
+               else
                   status = nf90_inq_varid(fid_kmt, 'mask', varid)
                   call ice_check_nc(status, subname//' ERROR: does '//trim(kmt_file)//&
                                     ' contain "kmt" or "mask" variable?', file=__FILE__, line=__LINE__)
@@ -671,7 +671,7 @@
             enddo
          enddo
          !$OMP END PARALLEL DO
-      endif 
+      endif
 
       if (trim(grid_type) == 'regional' .and. &
           (.not. (l_readCenter))) then
@@ -799,7 +799,7 @@
          enddo
       enddo
       !$OMP END PARALLEL DO
-      
+
       if (my_task == master_task) then
          close (nu_kmt)
       endif
@@ -888,14 +888,14 @@
          i, j, iblk, &
          ilo,ihi,jlo,jhi, &     ! beginning and end of physical domain
          fid_kmt                ! file id for netCDF kmt file
-      
+
       logical (kind=log_kind) :: diag
 
       real (kind=dbl_kind), dimension (nx_block,ny_block,max_blocks) :: &
          work1
 
       type (block) :: &
-         this_block           ! block information for current block          
+         this_block           ! block information for current block
 
       character(len=*), parameter :: subname = '(kmtmask_nc)'
 
@@ -905,7 +905,7 @@
       kmt(:,:,:) = c0
 
       call ice_open_nc(kmt_file,fid_kmt)
-      
+
       call ice_read_nc(fid_kmt,1,mask_fieldname,kmt,diag, &
                         field_loc=field_loc_center, &
                         field_type=field_type_scalar)
@@ -968,7 +968,7 @@
          work_g1
 
       integer(kind=int_kind) :: &
-         varid, status      
+         varid, status
 
       character(len=*), parameter :: subname = '(popgrid_nc)'
 
@@ -981,7 +981,7 @@
       call ice_open_nc(grid_file,fid_grid)
 
       diag = .true.       ! write diagnostic info
-   
+
       !-----------------------------------------------------------------
       ! lat, lon, angle
       !-----------------------------------------------------------------

--- a/cicecore/drivers/nuopc/cmeps/ice_prescribed_mod.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_prescribed_mod.F90
@@ -6,7 +6,7 @@ module ice_prescribed_mod
   ! prescribed.  Air/ice fluxes are computed to get surface temperature,
   ! Ice/ocean fluxes are set to zero, and ice dynamics are not calculated.
   ! Regridding and data cycling capabilities are included.
-  
+
   ! Note (8/8/2024): This code is dependent on CDEPS (to input ice data).
   ! In the interests of cleaner code, drivers/nuopc/cmeps now is too.
   ! If problematic, please see https://github.com/CICE-Consortium/CICE/pull/964 for alternatives.
@@ -215,7 +215,7 @@ contains
        ! If need initial cice values for coupling
        call ice_prescribed_run(idate, msec)
 #endif
-    
+
     end if  ! end of if prescribed ice mode
 
   end subroutine ice_prescribed_init

--- a/cicecore/drivers/nuopc/cmeps/ice_shr_methods.F90
+++ b/cicecore/drivers/nuopc/cmeps/ice_shr_methods.F90
@@ -926,7 +926,7 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        call ESMF_ClockGetAlarm(clock, alarmname="alarm_stop", alarm=alarm, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       call ESMF_AlarmGet(alarm, ringTime=NextAlarm, rc=rc) 
+       call ESMF_AlarmGet(alarm, ringTime=NextAlarm, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     case default

--- a/cicecore/shared/ice_arrays_column.F90
+++ b/cicecore/shared/ice_arrays_column.F90
@@ -80,10 +80,6 @@
          dhsn, &      ! depth difference for snow on sea ice and pond ice
          ffracn       ! fraction of fsurfn used to melt ipond
 
-      ! icepack_meltpond_sealvl.F90
-      real (kind=dbl_kind), public, dimension (:,:,:,:), allocatable :: &
-         pndasp       ! pond aspect is 2D with sealvl ponds
-
       ! icepack_shortwave.F90
       ! category albedos
       real (kind=dbl_kind), dimension (:,:,:,:), allocatable, public :: &
@@ -308,7 +304,6 @@
          meltsliq     (nx_block,ny_block,max_blocks), & ! snow melt mass (kg/m^2)
          meltsliqn    (nx_block,ny_block,ncat,max_blocks), & ! snow melt mass in category n (kg/m^2)
          dhsn         (nx_block,ny_block,ncat,max_blocks), & ! depth difference for snow on sea ice and pond ice
-         pndasp       (nx_block,ny_block,ncat,max_blocks), & ! pond aspect
          ffracn       (nx_block,ny_block,ncat,max_blocks), & ! fraction of fsurfn used to melt ipond
          alvdrn       (nx_block,ny_block,ncat,max_blocks), & ! visible direct albedo           (fraction)
          alidrn       (nx_block,ny_block,ncat,max_blocks), & ! near-ir direct albedo           (fraction)

--- a/cicecore/shared/ice_init_column.F90
+++ b/cicecore/shared/ice_init_column.F90
@@ -540,25 +540,18 @@
 
       subroutine init_meltponds_sealvl(apnd, hpnd, ipnd, dhsn)
 
-      use ice_arrays_column, only : pndasp
-
       real(kind=dbl_kind), dimension(:,:,:), intent(out) :: &
          apnd , & ! melt pond area fraction
          hpnd , & ! melt pond depth
          ipnd , & ! melt pond refrozen lid thickness
          dhsn     ! depth difference for snow on sea ice and pond ice
 
-      real(kind=dbl_kind) :: pndaspect
-
       character(len=*),parameter :: subname='(init_meltponds_sealvl)'
-
-      call icepack_query_parameters(pndaspect_out=pndaspect)
 
       apnd(:,:,:) = c0
       hpnd(:,:,:) = c0
       ipnd(:,:,:) = c0
       dhsn(:,:,:) = c0
-      pndasp(:,:,:,:) = pndaspect
 
       end subroutine init_meltponds_sealvl
 

--- a/cicecore/shared/ice_restart_column.F90
+++ b/cicecore/shared/ice_restart_column.F90
@@ -424,7 +424,7 @@
 
       subroutine write_restart_pond_sealvl()
 
-      use ice_arrays_column, only: dhsn, ffracn, pndasp
+      use ice_arrays_column, only: dhsn, ffracn
       use ice_fileunits, only: nu_dump_pond
       use ice_flux, only: fsnow
       use ice_state, only: trcrn
@@ -455,8 +455,6 @@
                                'dhs',ncat,diag)
       call write_restart_field(nu_dump_pond,0,ffracn(:,:,        :,:),'ruf8', &
                                'ffrac',ncat,diag)
-      call write_restart_field(nu_dump_pond,0,pndasp(:,:,        :,:),'ruf8', &
-                               'pndasp',ncat,diag)
 
       end subroutine write_restart_pond_sealvl
 
@@ -469,7 +467,7 @@
 
       subroutine read_restart_pond_sealvl()
 
-      use ice_arrays_column, only: dhsn, ffracn, pndasp
+      use ice_arrays_column, only: dhsn, ffracn
       use ice_fileunits, only: nu_restart_pond
       use ice_flux, only: fsnow
       use ice_state, only: trcrn
@@ -503,8 +501,6 @@
                               'dhs',ncat,diag,field_loc_center,field_type_scalar)
       call read_restart_field(nu_restart_pond,0,ffracn(:,:,        :,:),'ruf8', &
                               'ffrac',ncat,diag,field_loc_center,field_type_scalar)
-      call read_restart_field(nu_restart_pond,0, pndasp(:,:,       :,:),'ruf8', &
-                              'pndasp',1,diag,field_loc_center,field_type_scalar)
 
       end subroutine read_restart_pond_sealvl
 

--- a/configuration/scripts/ice_in
+++ b/configuration/scripts/ice_in
@@ -122,6 +122,8 @@
     restart_pond_topo = .false.
     tr_pond_lvl  = .true.
     restart_pond_lvl  = .false.
+    tr_pond_sealvl = .false.
+    restart_pond_sealvl = .false.
     tr_snow      = .false.
     restart_snow = .false.
     tr_iso       = .false.
@@ -147,6 +149,7 @@
     Tliquidus_max     = -0.1d0
     hfrazilmin        = 0.05d0
     floediam          = 300.0d0
+    tscale_pnd_drain  = 10.0d0
 /
 
 &dynamics_nml

--- a/configuration/scripts/machines/env.perlmutter_cray
+++ b/configuration/scripts/machines/env.perlmutter_cray
@@ -18,16 +18,16 @@ source ${MODULESHOME}/init/csh
 module load cpu
 module load PrgEnv-cray
 module unload cce
-module load cce/15.0.1
+module load cce/17.0.0
 module unload cray-mpich
-module load cray-mpich/8.1.25
+module load cray-mpich/8.1.28
 
 module unload cray-netcdf
 module unload cray-hdf5
-module load cray-hdf5/1.12.2.3
-module load cray-netcdf/4.9.0.3
+module load cray-hdf5/1.12.2.9
+module load cray-netcdf/4.9.0.9
 
-setenv NETCDF_PATH ${NETCDF_DIR}
+#setenv NETCDF_PATH ${NETCDF_DIR}
 limit coredumpsize unlimited
 limit stacksize unlimited
 setenv OMP_STACKSIZE 128M
@@ -38,7 +38,7 @@ endif
 setenv ICE_MACHINE_MACHNAME perlmutter
 setenv ICE_MACHINE_MACHINFO "HPE Cray EX AMD EPYC 7763 Milan, Slingshot-11 Interconnect"
 setenv ICE_MACHINE_ENVNAME cray
-setenv ICE_MACHINE_ENVINFO "Cray clang/Fortran 15.0.1, cray-mpich/8.1.25, netcdf/4.9.0.3"
+setenv ICE_MACHINE_ENVINFO "Cray clang/Fortran 17.0.0, cray-mpich/8.1.28, netcdf/4.9.0.9"
 setenv ICE_MACHINE_MAKE gmake
 setenv ICE_MACHINE_WKDIR $SCRATCH/CICE_RUNS
 setenv ICE_MACHINE_INPUTDATA /global/cfs/cdirs/e3sm/tcraig/cice-consortium

--- a/configuration/scripts/machines/env.perlmutter_gnu
+++ b/configuration/scripts/machines/env.perlmutter_gnu
@@ -15,19 +15,21 @@ source ${MODULESHOME}/init/csh
 #module unload PrgEnv-intel
 #module unload PrgEnv-nvidia
 #module unload gpu
+module unload darshan
 module load cpu
-module load PrgEnv-gnu
+module load PrgEnv-gnu/8.5.0
 module unload gcc
-module load gcc/11.2.0
+module unload gcc-native
+module load gcc-native/12.3
 module unload cray-mpich
-module load cray-mpich/8.1.25
+module load cray-mpich/8.1.28
 
 module unload cray-netcdf
 module unload cray-hdf5
-module load cray-hdf5/1.12.2.3
-module load cray-netcdf/4.9.0.3
+module load cray-hdf5/1.12.2.9
+module load cray-netcdf/4.9.0.9
 
-setenv NETCDF_PATH ${NETCDF_DIR}
+#setenv NETCDF_PATH ${NETCDF_DIR}
 limit coredumpsize unlimited
 limit stacksize unlimited
 setenv OMP_STACKSIZE 128M
@@ -38,7 +40,7 @@ endif
 setenv ICE_MACHINE_MACHNAME perlmutter
 setenv ICE_MACHINE_MACHINFO "HPE Cray EX AMD EPYC 7763 Milan, Slingshot-11 Interconnect"
 setenv ICE_MACHINE_ENVNAME gnu
-setenv ICE_MACHINE_ENVINFO "gnu c/fortran 11.2.0 20210728, cray-mpich/8.1.25, netcdf/4.9.0.3"
+setenv ICE_MACHINE_ENVINFO "gnu c/fortran 12.3.0, cray-mpich/8.1.28, netcdf/4.9.0.9"
 setenv ICE_MACHINE_MAKE gmake
 setenv ICE_MACHINE_WKDIR $SCRATCH/CICE_RUNS
 setenv ICE_MACHINE_INPUTDATA /global/cfs/cdirs/e3sm/tcraig/cice-consortium

--- a/configuration/scripts/machines/env.perlmutter_intel
+++ b/configuration/scripts/machines/env.perlmutter_intel
@@ -16,18 +16,18 @@ source ${MODULESHOME}/init/csh
 #module unload PrgEnv-nvidia
 #module unload gpu
 module load cpu
-module load PrgEnv-intel
+module load PrgEnv-intel/8.5.0
 module unload intel
-module load intel/2023.1.0
+module load intel/2023.2.0
 module unload cray-mpich
-module load cray-mpich/8.1.25
+module load cray-mpich/8.1.28
 
 module unload cray-netcdf
 module unload cray-hdf5
-module load cray-hdf5/1.12.2.3
-module load cray-netcdf/4.9.0.3
+module load cray-hdf5/1.12.2.9
+module load cray-netcdf/4.9.0.9
 
-setenv NETCDF_PATH ${NETCDF_DIR}
+#setenv NETCDF_PATH ${NETCDF_DIR}
 limit coredumpsize unlimited
 limit stacksize unlimited
 setenv OMP_STACKSIZE 128M
@@ -38,7 +38,7 @@ endif
 setenv ICE_MACHINE_MACHNAME perlmutter
 setenv ICE_MACHINE_MACHINFO "HPE Cray EX AMD EPYC 7763 Milan, Slingshot-11 Interconnect"
 setenv ICE_MACHINE_ENVNAME intel
-setenv ICE_MACHINE_ENVINFO "ifort 2021.9.0 20230302, Intel oneAPI DPC++/C++ 2023.1.0 (2023.1.0.20230320), cray-mpich/8.1.25, netcdf/4.9.0.3"
+setenv ICE_MACHINE_ENVINFO "ifort 2021.10.0 20230609, Intel oneAPI DPC++/C++ Compiler 2023.2.0 (2023.2.0.20230622)), cray-mpich/8.1.28, netcdf/4.9.0.9"
 setenv ICE_MACHINE_MAKE gmake
 setenv ICE_MACHINE_WKDIR $SCRATCH/CICE_RUNS
 setenv ICE_MACHINE_INPUTDATA /global/cfs/cdirs/e3sm/tcraig/cice-consortium


### PR DESCRIPTION
For detailed information about submitting Pull Requests (PRs) to the CICE-Consortium,
please refer to: <https://github.com/CICE-Consortium/About-Us/wiki/Resource-Index#information-for-developers>


## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Fix the initialization of tscale_pnd_drain and merge latest CICE main branch changes so that baseline comparison tests pass.
- [X] Developer(s): 
    @davidclemenssewall
- [X] Suggest PR reviewers from list in the column to the right.
   @dabail10 
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Passed baseline comparison test for run1day on conda linux. STILL NEEDS COMPARISON WITH CICE SUITE.
- How much do the PR code changes differ from the unmodified code? 
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [X] more substantial 
    - Differs from prior commit sealevelponds commit due to initialization of tscale_pond_drain. Should be bfb with consortium main.
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [X] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.
Sealevelponds branch was failing baseline comparison tests. This issue was found to be caused by the initialization of the tscale_pnd_drain parameter and has been fixed. Additionally, while fixing this issue an issue related to how sealevelponds was being initialized was discovered and fixed for the standalone driver. Those changes will need to be propagated to the other drivers. Regression tests have only been completed vs. a run1day test and so the full suite still needs to be run.